### PR TITLE
Filter types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@doubleswirve/quarterback",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "homepage": "https://doubleswirve.github.io/quarterback",
   "main": "lib/index.js",
   "files": [

--- a/src/lib/components/QuarterBack.js
+++ b/src/lib/components/QuarterBack.js
@@ -14,6 +14,7 @@ type Props = {
   conditions?: Array<Condition>,
   defaultCondition: string,
   fields?: Array<Field>,
+  filterTypes: Array<string>,
   inputsSeparator: string,
   lang: Object,
   operatorsConfig: OperatorsConfig,

--- a/src/lib/components/QuarterBack.js
+++ b/src/lib/components/QuarterBack.js
@@ -73,6 +73,7 @@ class QuarterBack extends React.Component<Props> {
       conditions,
       defaultCondition,
       fields,
+      filterTypes,
       inputsSeparator,
       lang,
       operatorsConfig,
@@ -92,6 +93,7 @@ class QuarterBack extends React.Component<Props> {
           conditions={conditions}
           defaultCondition={defaultCondition}
           fields={fields}
+          filterTypes={filterTypes}
           group={this.state}
           inputsSeparator={inputsSeparator}
           lang={lang}

--- a/src/lib/components/QuarterBack.js
+++ b/src/lib/components/QuarterBack.js
@@ -14,7 +14,7 @@ type Props = {
   conditions?: Array<Condition>,
   defaultCondition: string,
   fields?: Array<Field>,
-  filterTypes?: Array<string>,
+  filterTypes: Array<string>,
   inputsSeparator: string,
   lang: Object,
   operatorsConfig: OperatorsConfig,
@@ -29,6 +29,7 @@ class QuarterBack extends React.Component<Props> {
   static defaultProps = {
     actionIconMap: {},
     defaultCondition: 'AND',
+    filterTypes: [],
     inputsSeparator: ',',
     lang: {},
     operatorsConfig: {},

--- a/src/lib/components/QuarterBack.js
+++ b/src/lib/components/QuarterBack.js
@@ -14,7 +14,7 @@ type Props = {
   conditions?: Array<Condition>,
   defaultCondition: string,
   fields?: Array<Field>,
-  filterTypes: Array<string>,
+  filterTypes?: Array<string>,
   inputsSeparator: string,
   lang: Object,
   operatorsConfig: OperatorsConfig,

--- a/src/lib/components/QuarterBackActionCreate.js
+++ b/src/lib/components/QuarterBackActionCreate.js
@@ -158,8 +158,13 @@ class QuarterBackActionCreate extends React.Component<Props> {
   render () {
     const {
       action,
+      filterTypes,
       styleClassMap
     } = this.props
+
+    if (filterTypes.includes(action.QB)) {
+      return null
+    }
 
     const addClassAction = styleClassMap.QuarterBackAction != null
       ? styleClassMap.QuarterBackAction

--- a/src/lib/components/QuarterBackActionCreate.js
+++ b/src/lib/components/QuarterBackActionCreate.js
@@ -15,6 +15,7 @@ type Props = {
   actionIconMap: ActionIconMap,
   defaultCondition: string,
   fields: Array<Field>,
+  filterTypes: Array<string>,
   styleClassMap: StyleClassMap,
   types: Array<Type>,
   handleCreate: (data: Data) => void

--- a/src/lib/components/QuarterBackActions.js
+++ b/src/lib/components/QuarterBackActions.js
@@ -52,6 +52,7 @@ class QuarterBackActions extends React.Component<Props> {
       actionIconMap,
       defaultCondition,
       fields,
+      filterTypes,
       index,
       styleClassMap,
       types,
@@ -73,6 +74,7 @@ class QuarterBackActions extends React.Component<Props> {
               actionIconMap={actionIconMap}
               defaultCondition={defaultCondition}
               fields={fields}
+              filterTypes={filterTypes}
               styleClassMap={styleClassMap}
               types={types}
               handleCreate={handleCreate}

--- a/src/lib/components/QuarterBackActions.js
+++ b/src/lib/components/QuarterBackActions.js
@@ -14,6 +14,7 @@ type Props = {
   actionIconMap: ActionIconMap,
   defaultCondition: string,
   fields: Array<Field>,
+  filterTypes: Array<string>,
   index: number,
   styleClassMap: StyleClassMap,
   types: Array<Type>,

--- a/src/lib/components/QuarterBackGroup.js
+++ b/src/lib/components/QuarterBackGroup.js
@@ -84,11 +84,13 @@ class QuarterBackGroup extends React.Component<Props> {
 
   render () {
     const {
+      QB,
       QBComponent,
       actionIconMap,
       conditions,
       defaultCondition,
       fields,
+      filterTypes,
       group,
       index,
       inputsSeparator,
@@ -100,6 +102,10 @@ class QuarterBackGroup extends React.Component<Props> {
       types,
       handleDelete
     } = this.props
+
+    if (filterTypes.includes(QB)) {
+      return null
+    }
 
     const RulesComponent = QBComponent != null
       ? QBComponent

--- a/src/lib/components/QuarterBackGroup.js
+++ b/src/lib/components/QuarterBackGroup.js
@@ -127,6 +127,7 @@ class QuarterBackGroup extends React.Component<Props> {
           conditions={conditions}
           defaultCondition={defaultCondition}
           fields={fields}
+          filterTypes={filterTypes}
           index={index}
           styleClassMap={styleClassMap}
           types={types}

--- a/src/lib/components/QuarterBackGroup.js
+++ b/src/lib/components/QuarterBackGroup.js
@@ -22,6 +22,7 @@ type Props = {
   conditions: Array<Condition>,
   defaultCondition: string,
   fields: Array<Field>,
+  filterTypes: Array<string>,
   group: Group,
   index: number,
   inputsSeparator: string,

--- a/src/lib/components/QuarterBackGroup.js
+++ b/src/lib/components/QuarterBackGroup.js
@@ -140,6 +140,7 @@ class QuarterBackGroup extends React.Component<Props> {
           conditions={conditions}
           defaultCondition={defaultCondition}
           fields={fields}
+          filterTypes={filterTypes}
           inputsSeparator={inputsSeparator}
           lang={lang}
           operatorsConfig={operatorsConfig}

--- a/src/lib/components/QuarterBackHeader.js
+++ b/src/lib/components/QuarterBackHeader.js
@@ -33,6 +33,7 @@ class QuarterBackHeader extends React.Component<Props> {
       conditions,
       defaultCondition,
       fields,
+      filterTypes,
       index,
       styleClassMap,
       types,
@@ -57,6 +58,7 @@ class QuarterBackHeader extends React.Component<Props> {
           actionIconMap={actionIconMap}
           defaultCondition={defaultCondition}
           fields={fields}
+          filterTypes={filterTypes}
           index={index}
           styleClassMap={styleClassMap}
           types={types}

--- a/src/lib/components/QuarterBackHeader.js
+++ b/src/lib/components/QuarterBackHeader.js
@@ -16,6 +16,7 @@ type Props = {
   conditions: Array<Condition>,
   defaultCondition: string,
   fields: Array<Field>,
+  filterTypes: Array<string>,
   index: number,
   styleClassMap: StyleClassMap,
   types: Array<Type>,

--- a/src/lib/components/QuarterBackRules.js
+++ b/src/lib/components/QuarterBackRules.js
@@ -51,6 +51,7 @@ class QuarterBackRules extends React.Component<RulesProps> {
       actionIconMap,
       conditions,
       fields,
+      filterTypes,
       inputsSeparator,
       lang,
       operatorsConfig,
@@ -108,6 +109,7 @@ class QuarterBackRules extends React.Component<RulesProps> {
                 conditions={conditions}
                 defaultCondition={this.props.defaultCondition}
                 fields={fields}
+                filterTypes={filterTypes}
                 group={data}
                 index={index}
                 inputsSeparator={inputsSeparator}
@@ -142,6 +144,7 @@ class QuarterBackRules extends React.Component<RulesProps> {
               key={index}
               actionIconMap={actionIconMap}
               defaultCondition={defaultCondition}
+              filterTypes={filterTypes}
               group={data}
               index={index}
               inputsSeparator={inputsSeparator}

--- a/src/lib/utils/Rules.js
+++ b/src/lib/utils/Rules.js
@@ -12,6 +12,7 @@ export type RulesProps = {
   conditions: Array<Condition>,
   defaultCondition: string,
   fields: Array<Field>,
+  filterTypes: Array<string>,
   inputsSeparator: string,
   lang: Object,
   operatorsConfig: OperatorsConfig,


### PR DESCRIPTION
Add `filterTypes` prop that allows types to be filtered out and not rendered. This is primarily to satisfy a niche use case where we have existing rules but only want to display a subset of the types in the builder.